### PR TITLE
TD-5150: Resolved the issue in searching course using short name having multiple words(having space between the words)

### DIFF
--- a/App.cs
+++ b/App.cs
@@ -28,7 +28,16 @@ namespace Moodle_Migration
                     {
                         break;
                     }
+                    // Logic to consider search term with multiple word
+                    string[] parts = input.Split('=');
 
+                    if (parts.Length == 2)  // Ensure there's exactly one equal sign
+                    {
+                        string key = parts[0];   // Part before equal sign
+                        string[] keyArgs = parts[0].Split(' ');
+                        keyArgs[2] = keyArgs[2] + "=" + parts[1];
+                        commandArgs = keyArgs;
+                    }
                     await ProcessCommand(commandArgs);
                 }
             }


### PR DESCRIPTION
Resolved the issue in searching course using short name having multiple words(having space between the words)

**Screenshots**

**Before code change:**
Before fix, the result contains all data from DB
![image](https://github.com/user-attachments/assets/e76eb8ec-b435-4c37-afe8-5d5dd2586bb2)


**After code change:**

![image](https://github.com/user-attachments/assets/089bb460-76af-4715-bc12-bccbfc3957ba)
![image](https://github.com/user-attachments/assets/2eaa6517-4808-4686-8feb-8c2514cf13c4)
