### PR TITLE
TD-6195: SCORM package name should be in the file name when package is uploaded usig migration tool

### DIFF
--- a/Moodle-Migration-WebUI/Services/CategoryService.cs
+++ b/Moodle-Migration-WebUI/Services/CategoryService.cs
@@ -393,7 +393,7 @@ namespace Moodle_Migration.Services
                     { "courseid", elfhComponent.MoodleCourseId.ToString() },
                     { "section", "0" },
                     { "scormname", elfhComponent.ComponentName },
-                    { "foldername", elfhComponent.DevelopmentId },
+                    { "foldername", elfhComponent.SourceDevelopmentId },
                     { "base64Zip", base64Zip }
                 };
 


### PR DESCRIPTION
**_Before fix:_**
<img width="643" height="374" alt="image" src="https://github.com/user-attachments/assets/4b3bd165-0485-4122-a5dd-2e7752566a76" />

**_After fix_**

<img width="836" height="490" alt="image" src="https://github.com/user-attachments/assets/27a19a1f-0e8a-4a79-ae43-8b0a3dfd5290" />
