### PR TITLE
Fix for the issue password ennforment for oidc users

### DIFF
--- a/Moodle-Migration-WebUI/Services/UserService.cs
+++ b/Moodle-Migration-WebUI/Services/UserService.cs
@@ -382,7 +382,7 @@ namespace Moodle_Migration.Services
 
                 Dictionary<string, string> parameters = new Dictionary<string, string>
                 {
-                    { "users[0][createpassword]", "1" },
+                   // { "users[0][createpassword]", "1" },
                     { "users[0][username]", username },
                     { "users[0][email]", elfhUser.EmailAddress },
                     { "users[0][auth]", "oidc" },


### PR DESCRIPTION
https://hee-tis.atlassian.net/browse/TD-7431

Fixed the issue

After migration,  users were created with:

Authentication method: oidc
Force password change enabled (auth_forcepasswordchange = 1)

This caused the following issue on login:

“You cannot proceed without changing your password, however there is no available page for changing it.”

This occurs because OIDC-authenticated users do not have a Moodle password and therefore cannot access the password change page.

Root Cause

The user creation payload for migration was incorrectly including:

users[0][createpassword] = 1

This triggered Moodle’s password setup / reset flow, which is not compatible with OIDC authentication and resulted in forced password change being set on the user account.
FROM
<img width="502" height="382" alt="image" src="https://github.com/user-attachments/assets/5a07e9b7-ddb2-4a2e-9ab4-09a05aabe605" />

To
<img width="560" height="343" alt="image" src="https://github.com/user-attachments/assets/1e2691fd-d360-4fea-a16b-4459663356e9" />
